### PR TITLE
Fix typos in Django settings and admin

### DIFF
--- a/blogapp/blogapp/settings.py
+++ b/blogapp/blogapp/settings.py
@@ -130,7 +130,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-MESIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field

--- a/blogapp/xanga/admin.py
+++ b/blogapp/xanga/admin.py
@@ -7,7 +7,7 @@ class PostAdmin(admin.ModelAdmin):
     list_display = ('title', 'slug', 'status', 'created_on')
     list_filter = ("status",)
     search_fields = ['title', 'content']
-    prepopuilated_fields = {'slug': ('title',)}    
+    prepopulated_fields = {'slug': ('title',)}
 
 
 


### PR DESCRIPTION
## Summary
- correct `MEDIA_ROOT` setting typo
- fix `prepopulated_fields` attribute in admin

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c84d7dfb8832fb97ea5f546f6cb66